### PR TITLE
Fix placeholder link

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 </main>
 
 <footer>
-<p>Maintained by Portland Tech Volunteers. Updated July 2025. Submit additions via <a href="https://github.com/your-repo/issues" target="_blank">GitHub Issues</a>.</p>
+<p>Maintained by Portland Tech Volunteers. Updated July 2025. Submit additions via GitHub Issues.</p>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove unused GitHub Issues link

## Testing
- `curl -I https://www.worksourceoregon.org` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6866d10bb15883268f6dd73684a9034c