### PR TITLE
Add startup idea workshop event

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 <table class="resource-table">
 <tr><th>Event</th><th>Date</th><th>Price</th><th>Link</th></tr>
 <tr><td>Build with AI</td><td>July 11, 2025</td><td>Free</td><td><a href="https://www.eventbrite.com/e/lets-build-with-ai-tickets-1458815880569?aff=erelexpmlt" target="_blank">Eventbrite</a></td></tr>
+<tr><td>How to Evaluate &amp; Improve an Idea for a Startup</td><td>July 23, 2025</td><td>See link</td><td><a href="https://lu.ma/yg56sl7w" target="_blank">Details</a></td></tr>
 <tr><td>Startup Train</td><td>July 28, 2025</td><td>~$27</td><td><a href="https://lu.ma/wriqrbgh" target="_blank">RSVP</a></td></tr>
 </table>
 </section>


### PR DESCRIPTION
## Summary
- add "How to Evaluate & Improve an Idea for a Startup" workshop with date
- place workshop before Startup Train in the Curated Events table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686bf3b422988326864e6697c30ebea5